### PR TITLE
Read discharge pcic

### DIFF
--- a/pcic_dl.sh
+++ b/pcic_dl.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euxo pipefail
+
+
+curl -o '/Users/airvine/Dropbox/New Graph/fish-passage-22/Data/Discharge/pcic/baseflow.nc' 'https://data.pacificclimate.org/data/hydro_model_out/allwsbc.ACCESS1-0_rcp85_r1i1p1.1945to2099.BASEFLOW.nc.nc?BASEFLOW'$(printf %s '[27221:28060][196:222][200:274]'|jq -sRr @uri)
+
+curl -o '/Users/airvine/Dropbox/New Graph/fish-passage-22/Data/Discharge/pcic/runoff.nc' 'https://data.pacificclimate.org/data/hydro_model_out/allwsbc.ACCESS1-0_rcp85_r1i1p1.1945to2099.RUNOFF.nc.nc?RUNOFF'$(printf %s '[27221:28060][196:222][200:274]'|jq -sRr @uri)

--- a/read-discharge-pcic.R
+++ b/read-discharge-pcic.R
@@ -1,61 +1,26 @@
 library(ncdf4)
-library(terra)
+library(tidyverse)
 library(jsonlite)
 library(stringr)
 library(lubridate)
+
+
 # Read the JSON data into R
-json_data <- fromJSON("https://data.pacificclimate.org/portal/hydro_model_out/catalog/catalog.json")
+json_data <- fromJSON("https://data.pacificclimate.org/portal/hydro_model_out/catalog/catalog.json") 
 
-# Filter the data
-filtered_data <- json_data[str_detect(names(json_data), "BASEFLOW") & str_detect(names(json_data), "CanESM2_rcp45")]
+dat  <- tibble(
+    name = names(json_data),
+    url = unlist(json_data)
+  )
 
-# Open the dataset
-url <- filtered_data[[1]]
+# have a look at baseflow and runoff only
+dat_br <- dat %>% 
+  dplyr::filter(str_detect(name, "BASEFLOW") | str_detect(name, "RUNOFF"))
 
-nc_data <- nc_open(url)
+# make a bash file that can be run with `bash pcic_dl.sh` on commandline.
+pcic_dl_sh()
+pcic_dl_sh(var = "RUNOFF", 
+           append = TRUE)
 
-# Print an overview of the file
-# print(nc_data)
-
-
-# Read variables
-time <- ncvar_get(nc_data, "time")
-lat <- ncvar_get(nc_data, "lat")
-lon <- ncvar_get(nc_data, "lon")
-
-# Inspect the variables
-print(time)
-print(lat)
-# print(lon)
-
-# Convert these dates into "days since 1945-1-1"
-origin <- as.Date("1945-01-01")
-date_start <- as.Date("2019-07-13")
-date_end <- as.Date("2021-10-29")
-# dates <- seq(as_date("2019-07-13"), as_date("2021-10-29"), by = "day")
-
-# target_dates <- as.Date(dates)
-days_ind_start <- as.numeric(date_start - origin)
-days_ind_end <- as.numeric(date_end - origin)
-
-
-# Define your bounding box
-lat_min <- 53.32
-lat_max <- 54.89
-lon_min <- -127.53
-lon_max <- -122.92
-
-# Find indices that are closest to your target lat/lon
-lat_min_idx <- max(lat[lat < lat_min])
-lat_max_idx <- min(lat[lat > lat_max])
-lon_min_idx <- max(lon[lon < lon_min])
-lon_max_idx <- min(lon[lon > lon_max])
-
-
-# Close the ncdf4 file connection
-nc_close(nc_data)
-
-
-# gpt4 suggestion:  Using terra
-r <- rast(url)
-r_subset <- crop(r, ext(target_lon_min, target_lon_max, target_lat_min, target_lat_max))
+## Add baseflow and runoff to create discharge.  Not sure if we can/should do that first as it was
+# done after getting averages in bcfishpass.  

--- a/read-discharge-pcic.R
+++ b/read-discharge-pcic.R
@@ -1,0 +1,63 @@
+library(ncdf4)
+library(terra)
+library(jsonlite)
+library(stringr)
+library(lubridate)
+# Read the JSON data into R
+json_data <- fromJSON("https://data.pacificclimate.org/portal/hydro_model_out/catalog/catalog.json")
+
+# Filter the data
+filtered_data <- json_data[str_detect(names(json_data), "BASEFLOW") & str_detect(names(json_data), "CanESM2_rcp45")]
+
+# Open the dataset
+url <- filtered_data[[1]]
+
+nc_data <- nc_open(url)
+
+# Print an overview of the file
+# print(nc_data)
+
+
+# Read variables
+time <- ncvar_get(nc_data, "time")
+lat <- ncvar_get(nc_data, "lat")
+lon <- ncvar_get(nc_data, "lon")
+
+# Inspect the variables
+# print(time)
+# print(lat)
+# print(lon)
+
+# Convert these dates into "days since 1945-1-1"
+origin <- as.Date("1945-01-01")
+dates <- seq(as_date("2019-07-13"), as_date("2021-10-29"), by = "day")
+
+target_dates <- as.Date(dates)
+days_since_origin <- as.numeric(target_dates - origin)
+
+# Now, days_since_origin contains the number of days since 1945-1-1 for each target date
+# print(days_since_origin)
+
+# Find the closest indices for your target days
+date_indices <- sapply(days_since_origin, function(day) which.min(abs(time - day)))
+
+# Define your bounding box
+target_lat_min <- 53.32
+target_lat_max <- 54.89
+target_lon_min <- -127.53
+target_lon_max <- -122.92
+
+# Find indices that match the bounding box
+lat_indices <- which(lat >= target_lat_min & lat <= target_lat_max)
+lon_indices <- which(lon >= target_lon_min & lon <= target_lon_max)
+
+# print(lat_indices)
+# print(lon_indices)
+
+# Close the ncdf4 file connection
+nc_close(nc_data)
+
+
+# Using terra
+r <- rast(url)
+r_subset <- crop(r, ext(target_lon_min, target_lon_max, target_lat_min, target_lat_max))

--- a/read-discharge-pcic.R
+++ b/read-discharge-pcic.R
@@ -24,40 +24,38 @@ lat <- ncvar_get(nc_data, "lat")
 lon <- ncvar_get(nc_data, "lon")
 
 # Inspect the variables
-# print(time)
-# print(lat)
+print(time)
+print(lat)
 # print(lon)
 
 # Convert these dates into "days since 1945-1-1"
 origin <- as.Date("1945-01-01")
-dates <- seq(as_date("2019-07-13"), as_date("2021-10-29"), by = "day")
+date_start <- as.Date("2019-07-13")
+date_end <- as.Date("2021-10-29")
+# dates <- seq(as_date("2019-07-13"), as_date("2021-10-29"), by = "day")
 
-target_dates <- as.Date(dates)
-days_since_origin <- as.numeric(target_dates - origin)
+# target_dates <- as.Date(dates)
+days_ind_start <- as.numeric(date_start - origin)
+days_ind_end <- as.numeric(date_end - origin)
 
-# Now, days_since_origin contains the number of days since 1945-1-1 for each target date
-# print(days_since_origin)
-
-# Find the closest indices for your target days
-date_indices <- sapply(days_since_origin, function(day) which.min(abs(time - day)))
 
 # Define your bounding box
-target_lat_min <- 53.32
-target_lat_max <- 54.89
-target_lon_min <- -127.53
-target_lon_max <- -122.92
+lat_min <- 53.32
+lat_max <- 54.89
+lon_min <- -127.53
+lon_max <- -122.92
 
-# Find indices that match the bounding box
-lat_indices <- which(lat >= target_lat_min & lat <= target_lat_max)
-lon_indices <- which(lon >= target_lon_min & lon <= target_lon_max)
+# Find indices that are closest to your target lat/lon
+lat_min_idx <- max(lat[lat < lat_min])
+lat_max_idx <- min(lat[lat > lat_max])
+lon_min_idx <- max(lon[lon < lon_min])
+lon_max_idx <- min(lon[lon > lon_max])
 
-# print(lat_indices)
-# print(lon_indices)
 
 # Close the ncdf4 file connection
 nc_close(nc_data)
 
 
-# Using terra
+# gpt4 suggestion:  Using terra
 r <- rast(url)
 r_subset <- crop(r, ext(target_lon_min, target_lon_max, target_lat_min, target_lat_max))


### PR DESCRIPTION
oh wow. what a journey!!

`read-discharge-pcic.R` calls `pcic_dl_sh` function to build `bash` file that can be run with `bash pcic_dl.sh` on commandline.  Is computer specific b/c of S P A C E in the name of our shared dropbox folder 😲 . So to recreate the `.nc` files on dropbox you should rebuild the ` pcic_dl.sh` file with `read-discharge-pcic.R`


Apparently - according to comments in `bcfishpass` Makefile we:
##Add baseflow and runoff to create discharge.  

Not sure if we can/should do that first as it was done **after** getting averages in bcfishpass. Wouldn't think it would matter but did not add yet in case.

Tried to retrieve data by makeing a `Makefile` to run as per the methods in `bcfishpass` but uncovered this issue https://github.com/smnorris/bcfishpass/issues/452 

